### PR TITLE
refactor: 컨트롤러 토큰 인증 처리 및 추출 방식 개선, API 경로 수정 #10

### DIFF
--- a/src/main/java/kr/co/solpick/auth/security/SecurityConfig.java
+++ b/src/main/java/kr/co/solpick/auth/security/SecurityConfig.java
@@ -1,14 +1,10 @@
 package kr.co.solpick.auth.security;
 
-//import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-//import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
-//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-//import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -34,8 +30,9 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login").permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers("/auth/login").permitAll() // 로그인은 인증 없이 접근 가능
+//                        .requestMatchers("/member/**").permitAll() //순서가 중요 아래 코드보다 위에 있어야함
+                        .anyRequest().authenticated() // 다른 모든 요청은 인증 필요
                 );
 
         // 토큰 체크 필터 추가

--- a/src/main/java/kr/co/solpick/auth/security/TokenCheckFilter.java
+++ b/src/main/java/kr/co/solpick/auth/security/TokenCheckFilter.java
@@ -7,12 +7,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.solpick.auth.security.JWTUtil;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.security.SignatureException;
 import java.util.Map;
-
+import java.util.Collections;
 @Log4j2
 public class TokenCheckFilter extends OncePerRequestFilter {
     private JWTUtil jwtUtil;
@@ -33,8 +35,22 @@ public class TokenCheckFilter extends OncePerRequestFilter {
         log.info("JWUtil: "+jwtUtil.toString());
 
         // AccessToken 검증
+//        try {
+//            validateAccessToken(request);
+//            filterChain.doFilter(request, response);
+//        } catch (AccessTokenException e) {
+//            e.sendResponseError(response);
+//        }
+
         try {
-            validateAccessToken(request);
+            // 토큰 검증 및 claims 가져오기
+            Map<String, Object> claims = validateAccessToken(request);
+
+            // SecurityContext에 인증 정보 설정
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(claims, null, Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
             filterChain.doFilter(request, response);
         } catch (AccessTokenException e) {
             e.sendResponseError(response);

--- a/src/main/java/kr/co/solpick/external/recipick/client/RecipickOrderApiClient.java
+++ b/src/main/java/kr/co/solpick/external/recipick/client/RecipickOrderApiClient.java
@@ -32,7 +32,6 @@ public class RecipickOrderApiClient {
         try {
             log.info("레시픽 API 주문 내역 요청: memberId={}", memberId);
 
-            // 동적으로 URL 구성
             String url = baseUrl + "/api/order/history";
 
             HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/kr/co/solpick/member/controller/MemberController.java
+++ b/src/main/java/kr/co/solpick/member/controller/MemberController.java
@@ -1,25 +1,58 @@
 package kr.co.solpick.member.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import kr.co.solpick.order.dto.OrderHistoryResponseDTO;
 import kr.co.solpick.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/member")
+@RequestMapping("/api/member")
 @RequiredArgsConstructor
 @CrossOrigin(origins = {"http://localhost:3000/"})
 public class MemberController {
 
     private final OrderService orderService;
 
-    @GetMapping("/{memberId}/order")
-    public ResponseEntity<List<OrderHistoryResponseDTO>> getOrderHistory(@PathVariable int memberId) {
+//    @GetMapping("/{memberId}/order")
+//    public ResponseEntity<List<OrderHistoryResponseDTO>> getOrderHistory(@PathVariable int memberId) {
+//        log.info("주문 내역 요청 수신: memberId={}", memberId);
+//
+//        List<OrderHistoryResponseDTO> orderHistory = orderService.getOrderHistory(memberId);
+//
+//        if (orderHistory.isEmpty()) {
+//            log.info("주문 내역 없음: memberId={}", memberId);
+//            return ResponseEntity.noContent().build();
+//        }
+//
+//        log.info("주문 내역 조회 성공: memberId={}, 건수={}", memberId, orderHistory.size());
+//        return ResponseEntity.ok(orderHistory);
+//    }
+
+
+    @GetMapping("/order")
+    public ResponseEntity<List<OrderHistoryResponseDTO>> getOrderHistory() {
+        // SecurityContextHolder에서 인증 정보 가져오기
+        //요청이 서버에 도달하면, 먼저 TokenCheckFilter가 실행 이 필터는 요청 헤더에서 JWT 토큰을 추출하고 검증
+        //토큰 검증이 성공하면, TokenCheckFilter는 토큰에서 추출한 정보(claims)를 SecurityContextHolder에 저장
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Object principal = authentication.getPrincipal();
+
+        Map<String, Object> claims = (Map<String, Object>) principal;
+        // claims에서 memberId 가져오기
+        Object idObj = claims.get("id"); // 간단하게 하려면 익셉션 발생함
+        Integer memberId = (idObj instanceof Double) ?
+                ((Double) idObj).intValue() :
+                (Integer) idObj;
+
         log.info("주문 내역 요청 수신: memberId={}", memberId);
 
         List<OrderHistoryResponseDTO> orderHistory = orderService.getOrderHistory(memberId);


### PR DESCRIPTION
## #️⃣연관된 이슈
- #10
## 📝작업 내용
- 로그인을 제외한 solpick API에는 JWT 토큰 기반 인증을 적용하기 위해 컨트롤러 수정
- TokenCheckFilter에서 /api로 시작하는 경로만 토큰 검증을 하도록 하여, 엔드포인트 api/member/order로 수정
- TokenCheckFilter에서 토큰 검증 후 인증 정보를 SecurityContextHolder에 설정하도록 변경
