### PR TITLE
feat: 좋아요 레시피 목록 조회 API 구현 #44

### DIFF
--- a/src/main/java/kr/co/solpick/external/recipick/client/RecipickRecipeApiClient.java
+++ b/src/main/java/kr/co/solpick/external/recipick/client/RecipickRecipeApiClient.java
@@ -1,0 +1,77 @@
+package kr.co.solpick.external.recipick.client;
+
+import kr.co.solpick.external.recipick.dto.RecipickRequestDTO;
+import kr.co.solpick.external.recipick.dto.RecipickLikeResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Arrays;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RecipickRecipeApiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${recipick.api.base-url}")
+    private String baseUrl;
+
+    @Value("${recipick.api.key}")
+    private String apiKey;
+
+    /**
+     * 레시픽 API를 통해 사용자의 좋아요 레시피 목록 조회
+     *
+     * @param memberId 사용자 ID
+     * @return 좋아요한 레시피 목록, 오류 발생 시 빈 리스트 반환
+     */
+    public List<RecipickLikeResponseDTO> getLikedRecipes(int memberId) {
+        try {
+            log.info("레시픽 API 좋아요 레시피 목록 요청: memberId={}", memberId);
+
+            String url = baseUrl + "/api/recipe/likes";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            RecipickRequestDTO requestDTO = new RecipickRequestDTO();
+            requestDTO.setMemberId(memberId);
+            requestDTO.setApiKey(apiKey);
+
+            HttpEntity<RecipickRequestDTO> requestEntity = new HttpEntity<>(requestDTO, headers);
+
+            ResponseEntity<RecipickLikeResponseDTO[]> response = restTemplate.postForEntity(
+                    url,
+                    requestEntity,
+                    RecipickLikeResponseDTO[].class
+            );
+
+            // 응답 상태 코드에 따른 처리
+            if (response.getStatusCode() == HttpStatus.OK) {
+                List<RecipickLikeResponseDTO> result = Arrays.asList(response.getBody());
+                log.info("레시픽 API 좋아요 레시피 목록 응답: {} 개", result.size());
+                return result;
+            } else if (response.getStatusCode() == HttpStatus.NO_CONTENT) {
+                log.info("좋아요한 레시피가 없습니다: memberId={}", memberId);
+                return Collections.emptyList();
+            } else {
+                log.error("레시픽 API 좋아요 레시피 목록 조회 실패: 상태 코드 {}", response.getStatusCode());
+                return Collections.emptyList();
+            }
+        } catch (Exception e) {
+            log.error("레시픽 API 좋아요 레시피 목록 조회 실패", e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/kr/co/solpick/external/recipick/dto/RecipickLikeResponseDTO.java
+++ b/src/main/java/kr/co/solpick/external/recipick/dto/RecipickLikeResponseDTO.java
@@ -1,0 +1,16 @@
+package kr.co.solpick.external.recipick.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class RecipickLikeResponseDTO {
+    @JsonProperty("recipe_id")
+    private int recipeId;
+
+    @JsonProperty("recipe_name")
+    private String recipeName;
+
+    @JsonProperty("thumbnail_url")
+    private String thumbnailUrl;
+}

--- a/src/main/java/kr/co/solpick/member/controller/MemberController.java
+++ b/src/main/java/kr/co/solpick/member/controller/MemberController.java
@@ -21,22 +21,6 @@ public class MemberController {
 
     private final OrderService orderService;
 
-//    @GetMapping("/{memberId}/order")
-//    public ResponseEntity<List<OrderHistoryResponseDTO>> getOrderHistory(@PathVariable int memberId) {
-//        log.info("주문 내역 요청 수신: memberId={}", memberId);
-//
-//        List<OrderHistoryResponseDTO> orderHistory = orderService.getOrderHistory(memberId);
-//
-//        if (orderHistory.isEmpty()) {
-//            log.info("주문 내역 없음: memberId={}", memberId);
-//            return ResponseEntity.noContent().build();
-//        }
-//
-//        log.info("주문 내역 조회 성공: memberId={}, 건수={}", memberId, orderHistory.size());
-//        return ResponseEntity.ok(orderHistory);
-//    }
-
-
     @GetMapping("/order")
     public ResponseEntity<List<OrderHistoryResponseDTO>> getOrderHistory() {
         // SecurityContextHolder에서 인증 정보 가져오기

--- a/src/main/java/kr/co/solpick/recipe/controller/RecipeController.java
+++ b/src/main/java/kr/co/solpick/recipe/controller/RecipeController.java
@@ -1,0 +1,49 @@
+package kr.co.solpick.recipe.controller;
+
+import kr.co.solpick.external.recipick.dto.RecipickLikeResponseDTO;
+import kr.co.solpick.recipe.service.RecipeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/member/recipe")
+@RequiredArgsConstructor
+@CrossOrigin(origins = {"http://localhost:3000/"})
+public class RecipeController {
+    private final RecipeService recipeService;
+
+    @GetMapping("/likes")
+    public ResponseEntity<List<RecipickLikeResponseDTO>> getLikedRecipes() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = authentication.getPrincipal();
+        Map<String, Object> claims = (Map<String, Object>) principal;
+
+        Object idObj = claims.get("recipickUserId");
+        Integer memberId = (idObj instanceof Double) ?
+                ((Double) idObj).intValue() :
+                (Integer) idObj;
+
+        log.info("좋아요 레시피 목록 요청 수신: recipickmemberId={}", memberId);
+
+        List<RecipickLikeResponseDTO> likedRecipes = recipeService.getLikedRecipes(memberId);
+
+        if (likedRecipes.isEmpty()) {
+            log.info("좋아요 레시피 없음: recipickmemberId={}", memberId);
+            return ResponseEntity.noContent().build();
+        }
+
+        log.info("좋아요 레시피 목록 조회 성공: memberId={}, 건수={}", memberId, likedRecipes.size());
+        return ResponseEntity.ok(likedRecipes);
+    }
+}

--- a/src/main/java/kr/co/solpick/recipe/service/RecipeService.java
+++ b/src/main/java/kr/co/solpick/recipe/service/RecipeService.java
@@ -1,0 +1,21 @@
+package kr.co.solpick.recipe.service;
+
+import kr.co.solpick.external.recipick.client.RecipickRecipeApiClient;
+import kr.co.solpick.external.recipick.dto.RecipickLikeResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecipeService {
+    private final RecipickRecipeApiClient recipickRecipeApiClient;
+
+    public List<RecipickLikeResponseDTO> getLikedRecipes(int memberId) {
+        log.info("좋아요 레시피 목록 조회 서비스 호출: memberId={}", memberId);
+        return recipickRecipeApiClient.getLikedRecipes(memberId);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #44 
## 📝주요 작업 내용
인증된 사용자 정보에서 recipickUserId 추출 후 RecipeService를 통해 외부 레시픽 API 호출
- RecipeController: 사용자의 좋아요 레시피 목록 조회 API 엔드포인트
- RecipickRecipeApiClient: 외부 레시픽 API를 호출하는 클라이언트
- RecipickLikeResponseDTO: 레시픽 API 응답 데이터 



