### PR TITLE
feat: 레시피 스텝 전달 API 구현 #46

### DIFF
--- a/src/main/java/kr/co/solpick/external/recipick/client/RecipickRecipeApiClient.java
+++ b/src/main/java/kr/co/solpick/external/recipick/client/RecipickRecipeApiClient.java
@@ -2,6 +2,8 @@ package kr.co.solpick.external.recipick.client;
 
 import kr.co.solpick.external.recipick.dto.RecipickRequestDTO;
 import kr.co.solpick.external.recipick.dto.RecipickLikeResponseDTO;
+import kr.co.solpick.external.recipick.dto.RecipickStepRequestDTO;
+import kr.co.solpick.external.recipick.dto.RecipickStepResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -71,6 +73,51 @@ public class RecipickRecipeApiClient {
             }
         } catch (Exception e) {
             log.error("레시픽 API 좋아요 레시피 목록 조회 실패", e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 레시픽 API를 통해 레시피의 스텝 정보 조회
+     *
+     * @param recipeId 레시피 ID
+     * @return 레시피 스텝 목록, 오류 발생 시 빈 리스트 반환
+     */
+    public List<RecipickStepResponseDTO> getRecipeSteps(int recipeId) {
+        try {
+            log.info("레시픽 API 레시피 스텝 조회 요청: recipeId={}", recipeId);
+
+            String url = baseUrl + "/api/recipe/steps";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            RecipickStepRequestDTO requestDTO = new RecipickStepRequestDTO();
+            requestDTO.setRecipeId(recipeId);
+            requestDTO.setApiKey(apiKey);
+
+            HttpEntity<RecipickStepRequestDTO> requestEntity = new HttpEntity<>(requestDTO, headers);
+
+            ResponseEntity<RecipickStepResponseDTO[]> response = restTemplate.postForEntity(
+                    url,
+                    requestEntity,
+                    RecipickStepResponseDTO[].class
+            );
+
+            // 응답 상태 코드에 따른 처리
+            if (response.getStatusCode() == HttpStatus.OK) {
+                List<RecipickStepResponseDTO> result = Arrays.asList(response.getBody());
+                log.info("레시픽 API 레시피 스텝 조회 응답: {} 개", result.size());
+                return result;
+            } else if (response.getStatusCode() == HttpStatus.NO_CONTENT) {
+                log.info("레시피 스텝이 없습니다: recipeId={}", recipeId);
+                return Collections.emptyList();
+            } else {
+                log.error("레시픽 API 레시피 스텝 조회 실패: 상태 코드 {}", response.getStatusCode());
+                return Collections.emptyList();
+            }
+        } catch (Exception e) {
+            log.error("레시픽 API 레시피 스텝 조회 실패", e);
             return Collections.emptyList();
         }
     }

--- a/src/main/java/kr/co/solpick/external/recipick/dto/RecipickStepRequestDTO.java
+++ b/src/main/java/kr/co/solpick/external/recipick/dto/RecipickStepRequestDTO.java
@@ -1,0 +1,11 @@
+package kr.co.solpick.external.recipick.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class RecipickStepRequestDTO {
+    @JsonProperty("recipe_id")
+    private int recipeId;
+    private String apiKey;
+}

--- a/src/main/java/kr/co/solpick/external/recipick/dto/RecipickStepResponseDTO.java
+++ b/src/main/java/kr/co/solpick/external/recipick/dto/RecipickStepResponseDTO.java
@@ -1,0 +1,12 @@
+package kr.co.solpick.external.recipick.dto;
+
+import lombok.Data;
+
+@Data
+public class RecipickStepResponseDTO {
+    private int stepId;
+    private int sort;
+    private String description;
+    private String imgUrl;
+    private int time;
+}

--- a/src/main/java/kr/co/solpick/recipe/controller/RecipeController.java
+++ b/src/main/java/kr/co/solpick/recipe/controller/RecipeController.java
@@ -1,16 +1,14 @@
 package kr.co.solpick.recipe.controller;
 
 import kr.co.solpick.external.recipick.dto.RecipickLikeResponseDTO;
+import kr.co.solpick.external.recipick.dto.RecipickStepResponseDTO;
 import kr.co.solpick.recipe.service.RecipeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
@@ -45,5 +43,21 @@ public class RecipeController {
 
         log.info("좋아요 레시피 목록 조회 성공: memberId={}, 건수={}", memberId, likedRecipes.size());
         return ResponseEntity.ok(likedRecipes);
+    }
+
+
+    @GetMapping("/{recipeId}/steps")
+    public ResponseEntity<List<RecipickStepResponseDTO>> getRecipeSteps(@PathVariable int recipeId) {
+        log.info("레시피 스텝 요청 수신: recipeId={}", recipeId);
+
+        List<RecipickStepResponseDTO> recipeSteps = recipeService.getRecipeSteps(recipeId);
+
+        if (recipeSteps.isEmpty()) {
+            log.info("레시피 스텝 없음: recipeId={}", recipeId);
+            return ResponseEntity.noContent().build();
+        }
+
+        log.info("레시피 스텝 조회 성공: recipeId={}, 건수={}", recipeId, recipeSteps.size());
+        return ResponseEntity.ok(recipeSteps);
     }
 }

--- a/src/main/java/kr/co/solpick/recipe/service/RecipeService.java
+++ b/src/main/java/kr/co/solpick/recipe/service/RecipeService.java
@@ -2,6 +2,7 @@ package kr.co.solpick.recipe.service;
 
 import kr.co.solpick.external.recipick.client.RecipickRecipeApiClient;
 import kr.co.solpick.external.recipick.dto.RecipickLikeResponseDTO;
+import kr.co.solpick.external.recipick.dto.RecipickStepResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,5 +18,13 @@ public class RecipeService {
     public List<RecipickLikeResponseDTO> getLikedRecipes(int memberId) {
         log.info("좋아요 레시피 목록 조회 서비스 호출: memberId={}", memberId);
         return recipickRecipeApiClient.getLikedRecipes(memberId);
+    }
+
+    /**
+     * 레시피의 단계별 조리 방법 조회
+     */
+    public List<RecipickStepResponseDTO> getRecipeSteps(int recipeId) {
+        log.info("레시피 스텝 조회 서비스 호출: recipeId={}", recipeId);
+        return recipickRecipeApiClient.getRecipeSteps(recipeId);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #44
- #46 

## 📝작업 내용
- `RecipickRecipeApiClient`: 외부 API 호출을 담당하는 클라이언트 구현
  - `getLikedRecipes`: 사용자의 좋아요 레시피 목록 조회
  - `getRecipeSteps`: 특정 레시피의 조리 단계 조회

- `RecipeService`: API 클라이언트를 통해서 처리
  - 좋아요 레시피 및 레시피 스텝 조회 메서드 

- `RecipeController`: API 엔드포인트 
  - `/api/member/recipe/likes`: 좋아요 레시피 조회
  - `/api/member/recipe/{recipeId}/steps`: 레시피 스텝 

- `RecipickLikeResponseDTO`: 좋아요 레시피 정보 응답
- `RecipickStepResponseDTO`: 레시피 조리 스텝 정보 응답

